### PR TITLE
tradefed: don't crash when interactive test is present

### DIFF
--- a/tradefed/__init__.py
+++ b/tradefed/__init__.py
@@ -183,6 +183,8 @@ class Tradefed(BasePlugin):
             # find all tests
             if 'actions' in job_definition.keys():
                 for test_action in [action for action in job_definition['actions'] if'test' in action.keys()]:
+                    if 'definitions' not in test_action['test'].keys():
+                        continue
                     for test_definition in test_action['test']['definitions']:
                         logger.debug("Processing test %s" % test_definition['name'])
                         if "tradefed.yaml" in test_definition['path']:  # is there any better heuristic?


### PR DESCRIPTION
Interactive test block in LAVA doesn't contain 'definitions' key in the
test action. Plugin was expecting each test action to contain
'definitions' and was crashing when it was missing. This patch fixes the
problem by ommiting the test actions without 'definitions'.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>