### PR TITLE
tradefed: ignore test names without "/"

### DIFF
--- a/test/test_tradefed.py
+++ b/test/test_tradefed.py
@@ -676,6 +676,15 @@ class TradefedLogsPluginTest(unittest.TestCase):
         self.assertIn("java.lang.Error", test_mock.log)
         test_mock.save.assert_called_once()
 
+    def test_assign_test_log_no_slash(self):
+        test_mock = Mock()
+        suite_mock = PropertyMock(return_value="cts-lkft.arm64-v8a.module_foo")
+        type(test_mock).suite = suite_mock
+        name_mock = PropertyMock(return_value="TestCaseBar.test_bar4")
+        type(test_mock).name = name_mock
+        self.plugin._assign_test_log(StringIO(XML_RESULTS), [test_mock])
+        test_mock.save.assert_not_called()
+
     def test_assign_test_log_complex_name(self):
         test_mock = Mock()
         suite_mock = PropertyMock(return_value="cts-lkft/arm64-v8a.module_foo/TestCaseBar.first_subname/second_subname.third_subname")

--- a/tradefed/__init__.py
+++ b/tradefed/__init__.py
@@ -54,6 +54,10 @@ class Tradefed(BasePlugin):
             # search in etree for relevant test
             logger.debug("processing %s/%s" % (test.suite, test.name))
             test_suite_name_list = str(test.suite).split("/")
+            if len(test_suite_name_list) <= 1:
+                # assume that test results produced by LAVA
+                # and test-definitions always contain at least one "/"
+                continue
             test_suite_name = test_suite_name_list[1]
             test_suite_abi = None
             if "." in test_suite_name:


### PR DESCRIPTION
It is assumed this plugin only works for test results produced using
LAVA and Linaro test-definitions. Therefore missing "/" character is a
sign of 'some other test' that won't produce tradefed results tarball.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>