### PR TITLE
tradefed: fix total summaries for test run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='squad-linaro-plugins',
-    version='1.12',
+    version='1.13',
     author='Milosz Wasilewski',
     author_email='milosz.wasilewski@linaro.org',
     url='https://github.com/linaro/squadplugins',

--- a/tradefed/__init__.py
+++ b/tradefed/__init__.py
@@ -173,13 +173,17 @@ class Tradefed(BasePlugin):
                     ))
                     if decoded_test_result is True:
                         tr_status_dict[suite.slug].tests_pass += 1
+                        tr_status_dict[None].tests_pass += 1
                     elif decoded_test_result is False:
                         if test_issues:
                             tr_status_dict[suite.slug].tests_xfail += 1
+                            tr_status_dict[None].tests_xfail += 1
                         else:
                             tr_status_dict[suite.slug].tests_fail += 1
+                            tr_status_dict[None].tests_fail += 1
                     else:
                         tr_status_dict[suite.slug].tests_skip += 1
+                        tr_status_dict[None].tests_skip += 1
                 Test.objects.bulk_create(test_list)
         # retrieve all tests that should be associated with issues
         issue_tests = testrun.tests.filter(name__in=issues.keys())


### PR DESCRIPTION
When adding new tests extracted from CTS/VTS zip file TestRun summary
needs to be updated. This patch fixes a bug when the summaries didn't
include newly created Test objects.

Signed-off-by: Milosz Wasilewski <milosz.wasilewski@linaro.org>