### PR TITLE
tradefed: use deprecated Attachment data field

### DIFF
--- a/test/test_tradefed.py
+++ b/test/test_tradefed.py
@@ -551,7 +551,7 @@ class TradefedLogsPluginTest(unittest.TestCase):
         type(content_mock).read = lambda s: 'abc'
         type(extracted_file_mock).contents = content_mock
         self.plugin._create_testrun_attachment(testrun_mock, name, extracted_file_mock, "text/plain")
-        testrun_mock.attachments.create.assert_called_with(data='abc', filename='name', length=2, mimetype='text/plain')
+        testrun_mock.attachments.create.assert_called_with(old_data='abc', filename='name', length=2, mimetype='text/plain')
 
     @patch("tradefed.Tradefed._download_results")
     def test_get_from_artifactorial(self, download_results_mock):

--- a/tradefed/__init__.py
+++ b/tradefed/__init__.py
@@ -449,7 +449,7 @@ class Tradefed(BasePlugin):
         data = extracted_file.contents.read()
         attachment = testrun.attachments.create(
             filename = name,
-            data = data,
+            old_data = data,
             length = extracted_file.length,
             mimetype = mimetype
         )


### PR DESCRIPTION
This patch is adjusts squadplugins according to https://github.com/Linaro/squad/pull/913