### PR TITLE
tradefed: force main thread to wait subtasks

### DIFF
--- a/test/test_tradefed.py
+++ b/test/test_tradefed.py
@@ -848,13 +848,27 @@ class TradefedLogsPluginTest(unittest.TestCase):
         type(testrun).build = PropertyMock(return_value=build)
         type(testrun).pk = PropertyMock(return_value=1)
 
-        def chord_mock_return_func(tasklist):
-            pass
+        class CeleryGroupMock:
+            def waiting(self):
+                return False
 
-        def chord_mock_func(task):
-            return chord_mock_return_func
+            def successful(self):
+                return True
 
-        def update_s(testrun_pk):
+            def completed_count(self):
+                return 0
+
+        class ApplyAsyncMock():
+            def __init__(self, tasklist):
+                pass
+
+            def apply_async(self):
+                return CeleryGroupMock()
+
+        def celery_group_mock_func(tasklist):
+            return ApplyAsyncMock(tasklist)
+
+        def update_build_status_mock(testrun_pk):
             return {}
 
         def goc_mock(*args, **kwargs):
@@ -885,8 +899,8 @@ class TradefedLogsPluginTest(unittest.TestCase):
         with patch("squad.core.models.SuiteMetadata.objects.get_or_create", goc_mock), \
                 patch("squad.core.models.Suite.objects.get_or_create", goc_mock), \
                 patch("squad.core.models.KnownIssue.objects.get_or_create", goc_knownissues), \
-                patch("tradefed.celery_chord", chord_mock_func), \
-                patch("tradefed.tasks.update_build_status.s", update_s), \
+                patch("tradefed.celery_group", celery_group_mock_func), \
+                patch("tradefed.update_build_status", update_build_status_mock), \
                 patch("tradefed.Tradefed._enqueue_testcases_chunk", enqueue_testcases):
             self.plugin._extract_cts_results(xmlbuf, testrun, 'cts')
 

--- a/tradefed/tasks.py
+++ b/tradefed/tasks.py
@@ -3,7 +3,7 @@ import json
 
 from collections import defaultdict
 
-from squad.core.models import SuiteMetadata, Test, KnownIssue, Status, TestRun, ProjectStatus, PluginScratch
+from squad.core.models import SuiteMetadata, Test, KnownIssue, Status, TestRun, PluginScratch
 from squad.celery import app as celery
 from squad.core.utils import join_name
 from squad.core.tasks import RecordTestRunStatus
@@ -13,15 +13,13 @@ logger = logging.getLogger()
 
 
 @celery.task(queue='ci_fetch')
-def update_build_status(results_list, testrun_id):
+def update_build_status(testrun_id):
     testrun = TestRun.objects.get(pk=testrun_id)
 
-    # Comput stats all at once
+    # Compute stats all at once
     Status.objects.filter(test_run=testrun).all().delete()
     testrun.status_recorded = False
     RecordTestRunStatus()(testrun)
-
-    ProjectStatus.create_or_update(testrun.build)
 
 
 @celery.task(queue='ci_fetch')


### PR DESCRIPTION
When celery_chord was introduced to process CTS/VTS tests, it added a bug in SQUAD that makes build finished events to get triggered before all testjobs' results to be fetched completely.

The main thread triggers many subtasks via celery_chord and returns right away, with all subtasks offloaded to the queue.

With the main thread returned, SQUAD would consider the postprocessing of tradefed plugin to be done and events would be triggered, like build callbacks.

This patch adds a while loop in the main thread to wait for its parallel subtasks to finish.